### PR TITLE
Alternate between config.yaml and env var lookup

### DIFF
--- a/pvHelpers/pvHelpers.py
+++ b/pvHelpers/pvHelpers.py
@@ -11,9 +11,10 @@ class MetaConf(type):
         config_dir = dct["config_dir"]
 
         # Precedence
-        # 0. PREVEIL_MODE
-        # 1. conf/default-mode
-        # 2. 'dev'
+        # 0. Env
+        # 1. PREVEIL_MODE
+        # 2. conf/default-mode
+        # 3. 'dev'
         mode = os.environ.get('PREVEIL_MODE')
         if mode is None:
             path = os.path.join(config_dir, "default-mode")
@@ -23,12 +24,32 @@ class MetaConf(type):
             except IOError:
                 mode = "dev"
         cls.mode = mode
+        cls.data = {}
 
-        path = os.path.join(config_dir, "config.yaml")
-        with open(path, 'r') as f:
-            c = yaml.load(f.read())
-            if c.has_key(mode) is False:
-                raise Exception("error, exiting: PREVEIL_MODE={} unavailable at {}".format(mode, path))
-        cls.data = c
+        try:
+            path = os.path.join(config_dir, "config.yaml")
+            with open(path, 'r') as f:
+                c = yaml.load(f.read())
+                if c.has_key(mode) is False:
+                    raise Exception("error, exiting: PREVEIL_MODE={} unavailable at {}".format(mode, path))
+            cls.data = c
+        except IOError:
+            pass
+
+        cls.path = path
 
         super(MetaConf, cls).__init__(name, bases, dct)
+
+    def _getValue(cls, key, override_mode=None):
+        value = os.environ.get(key)
+        if value is not None:
+            return value
+
+        if override_mode is None:
+            override_mode = cls.mode
+
+        if cls.data.has_key(override_mode) == False:
+            raise Exception("error, exiting: PREVEIL_MODE={} unavailable at {} for key {}".format(override_mode, cls.path, key))
+        value = cls.data[override_mode][key]
+
+        return value

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(name='pvHelpers',
-      version='1.0',
+      version='1.1',
       packages=['pvHelpers'],
       install_requires=[
         "PyYAML==3.11"


### PR DESCRIPTION
Now the pvHelpers can lookup either on env var or he can fallback to the config.yaml file with the PREVEIL_MODE specified.
you can use the get method to have that degree of abstraction.
Config.get("OSX_SLAVE_NAME", override_mode="test")