### PR TITLE
Clean up pacparser memory resources

### DIFF
--- a/pvHelpers/proxy_config/proxy_config_item.py
+++ b/pvHelpers/proxy_config/proxy_config_item.py
@@ -128,7 +128,7 @@ class ProxyConfigItem(object):
 
     def add_or_update(self, type_, proxy_obj):
         if type_ in ProxyConfigItem.PROTOCOL_TYPES:
-            if type_ == IPProtocol.PAC and self.proxies.get(type_) is not None:
+            if type_ == IPProtocol.PAC and type_ in self.proxies:
                 # clean up current pac parser js engine
                 del self.proxies[type_]
             self.proxies[type_] = proxy_obj

--- a/pvHelpers/proxy_config/proxy_config_util.py
+++ b/pvHelpers/proxy_config/proxy_config_util.py
@@ -173,6 +173,8 @@ class ProxyConfig(object):
                 self.set_basic_auth_cred(proxy_config_item)
 
     def get_update(self):
+        if self.os_proxy_setting and IPProtocol.PAC in self.os_proxy_setting.proxies:
+            del self.os_proxy_setting.proxies[IPProtocol.PAC]
         self.add_or_update(ProxyKey.OS_PROXY_SETTINGS, get_os_proxies())
 
     @property


### PR DESCRIPTION
The previous patch didn't take into account that we initialize a new proxy_config_item everytime.

Therefore, we also need to perform pacparser clean up top down from proxy_config main get_update method.