### PR TITLE
DA-779: Return error for get_os_proxies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.platform == "win32":
 
 setup(
     name="pvHelpers",
-    version="5.0.6",
+    version="5.0.7",
     packages=find_packages(),
     install_requires=install_requires,
 )


### PR DESCRIPTION
This PR:
- Return status error if fetching os proxies failed.
- Add support for a func with bool status to our Retry wrapper.