### PR TITLE
Saman/app config env var initialization

### DIFF
--- a/pvHelpers/application_config.py
+++ b/pvHelpers/application_config.py
@@ -91,9 +91,8 @@ class ApplicationConfig(object):
         else:
             for k in self.config_keys:
                 if k not in self.__config__:
-                    if k == "mode":
-                        k = "preveil-mode"
-                    self.__config__[k] = os.environ[k.replace("-", "_").upper()]
+                    env_key = "PREVEIL_MODE" if k == "mode" else k.replace("-", "_").upper()
+                    self.__config__[k] = os.environ[env_key]
 
 
         # assert initialization of all the expected `config_keys`

--- a/pvHelpers/application_config.py
+++ b/pvHelpers/application_config.py
@@ -40,12 +40,10 @@ class ApplicationConfig(object):
         if self.initialized:
             return
 
-        if master_port is None and (mode is None or config_file is None):
-            raise ValueError(u"Process needs to be initialized either as `Master` or `Replica`")
-
-
         # master instance
-        if (mode and config_file):
+        if mode:
+            if not config_file:
+                raise ValueError(u"missing config file")
             status, confs = readYAMLConfig(config_file)
             if not status:
                 raise ValueError(u"failed reading provided config_file: {}".format(config_file))
@@ -90,12 +88,12 @@ class ApplicationConfig(object):
                 else:
                     break
 
-        # TODO: master config initialization with environment
-        # else:
-        #     self.__config__["mode"] = unicode(os.environ["PREVEIL_MODE"])
-        #      for k in self.config_keys:
-        #          if k not in self.__config__:
-        #             self.__config__[k] = os.environ.get(k.replace("-", "_").upper())
+        else:
+            for k in self.config_keys:
+                if k not in self.__config__:
+                    if k == "mode":
+                        k = "preveil-mode"
+                    self.__config__[k] = os.environ[k.replace("-", "_").upper()]
 
 
         # assert initialization of all the expected `config_keys`

--- a/pvHelpers/application_config.py
+++ b/pvHelpers/application_config.py
@@ -90,9 +90,8 @@ class ApplicationConfig(object):
 
         else:
             for k in self.config_keys:
-                if k not in self.__config__:
-                    env_key = "PREVEIL_MODE" if k == "mode" else k.replace("-", "_").upper()
-                    self.__config__[k] = os.environ[env_key]
+                env_key = "PREVEIL_MODE" if k == "mode" else k.replace("-", "_").upper()
+                self.__config__[k] = os.environ[env_key]
 
 
         # assert initialization of all the expected `config_keys`

--- a/tests/application_config_test.py
+++ b/tests/application_config_test.py
@@ -38,9 +38,10 @@ def test_master_init_config():
     master = MasterConfig()
     assert master.initialized == False
 
-    # should raise for being initialized neither as a master or replica
-    with pytest.raises(ValueError):
+    # should raise KeyError for missing enviroment variables
+    with pytest.raises(KeyError):
         master.initConfig()
+
 
     # should raise for not having `config_file`
     with pytest.raises(ValueError):

--- a/tests/application_config_test.py
+++ b/tests/application_config_test.py
@@ -4,7 +4,8 @@ import sys
 
 import pytest
 import requests
-from pvHelpers import ApplicationConfig, readYAMLConfig
+
+from pvHelpers import ApplicationConfig, randUnicode, readYAMLConfig
 
 TEST_CONFIG_PATH = unicode(os.path.join(os.path.dirname(__file__), "test_config.yaml"))
 
@@ -39,10 +40,19 @@ def test_master_init_config():
     assert master.initialized == False
 
     # should raise KeyError for missing enviroment variables
-    with pytest.raises(KeyError):
-        master.initConfig()
+    org_env, mocked_vars = os.environ, []
+    while len(master.config_keys) - len(mocked_vars) > 0:
+        with pytest.raises(KeyError):
+            master.initConfig()
+        mocked_vars.append(master.config_keys[len(mocked_vars)])
+        os.environ.update({k.replace("-", "_").upper() if k != "mode" else "PREVEIL_MODE": str(randUnicode(5)) for k in mocked_vars})
 
+    # should just go through when all the required keys are in env
+    master.initConfig()
+    os.environ = org_env
 
+    master = MasterConfig()
+    assert master.initialized == False
     # should raise for not having `config_file`
     with pytest.raises(ValueError):
         master.initConfig(mode=u"dev")


### PR DESCRIPTION
Patch enables usage of env vars to initialize ApplicationConfig (only required by new test suite at the moment).