### PR TITLE
DA-1732: Only change permissions for necessary items in data dir

### DIFF
--- a/pvHelpers/misc.py
+++ b/pvHelpers/misc.py
@@ -545,6 +545,7 @@ def initDaemonDataDirs(wd, mode, is_test=False):
             preveil_pwuid = pwd.getpwnam("preveil")
             preveil_uid = preveil_pwuid.pw_uid
             preveil_gid = preveil_pwuid.pw_gid
+            os.chown(wd, preveil_uid, preveil_gid)
             recur_chown(daemonDataDir(wd), preveil_uid, preveil_gid)
         else:
             pass


### PR DESCRIPTION
In some cases the data dir on macOS will contain SIP-protected folders that we cannot modify but also don't _need_ to modify.