### PR TITLE
Improve usability of crypto_server logs for debugging mature/Ravi's account

### DIFF
--- a/pvHelpers/connection_info.py
+++ b/pvHelpers/connection_info.py
@@ -103,7 +103,7 @@ def _get_conn_process_info_windows(remote_addr, remote_port, local_process_addr,
     remote_connections = filter(lambda c: c[1] == remote_addr and c[2] == remote_port and c[3] == local_process_addr and c[4] == local_process_port, tcp_connections)
 
     if len(remote_connections) != 1:
-        g_log.error(u"_get_conn_process_info_windows: couldn't fetch the connection file info, pcount: {}, p: {}".format(len(tcp_connections), tcp_connections))
+        g_log.error(u"_get_conn_process_info_windows: couldn't fetch the connection file info, pcount: {}".format(len(tcp_connections)))
         return False, None
 
     pid = remote_connections[0][0]

--- a/pvHelpers/misc.py
+++ b/pvHelpers/misc.py
@@ -219,7 +219,7 @@ class _LogWrapper(object):
         # clients who put their computer to sleep at night will never get a log
         # rotation. Just use RotatingFileHandler so we can avoid exploded logs.
         handler = logging.handlers.RotatingFileHandler(
-            logpath, maxBytes=1000000, backupCount=20)
+            logpath, maxBytes=1000000, backupCount=35)
         formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
         handler.setFormatter(formatter)
         self.logobj.addHandler(handler)


### PR DESCRIPTION
Two changes here:
(1) When we log "couldn't fetch the connection file info" error, stop also printing out 100+ numerical values for tcp_connections
(2) Maximum number of log files for a given service is moved from 20 to 35. This is done instead of the original intention of switching to TimedRotatingFileHandler and preserving logs for the last 24 hours, as this brings with it the danger that log rotation simply will not happen if a user's machine is asleep at midnight/time specified.