### PR TITLE
Import pywintypes as necessary

### DIFF
--- a/pvHelpers/connection_info.py
+++ b/pvHelpers/connection_info.py
@@ -2,6 +2,7 @@ import subprocess, sys, re, socket, struct, collections
 from pvHelpers import g_log, NOT_ASSIGNED, toInt, LUserInfoWin, LUserInfo, params
 
 if sys.platform == "win32":
+    import pywintypes
     from .win_helpers import *
 
 


### PR DESCRIPTION
Otherwise, we try to catch pywintypes.error as an exception type and hit an import error rather than logging the real error.